### PR TITLE
fix: exclusively use githubreleases version update strategy to exclude prereleases

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,6 @@
+bot:
+  version_updates:
+    sources: [githubreleases]
 github:
   branch_name: main
   tooling_branch_name: main


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] ~Bumped the build number (if the version is unchanged)~
* [x] ~Reset the build number to `0` (if the version changed)~
* [x] Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is the most elegant fix to prevent the autotick-bot from making version updates for prereleases.

See https://github.com/regro/cf-scripts/pull/2837 and https://github.com/regro/cf-scripts/issues/324